### PR TITLE
Checks environment variables for empty strings

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -252,9 +252,11 @@ func newDockerContainerHandler(
 	// split env vars to get metadata map.
 	for _, exposedEnv := range metadataEnvs {
 		for _, envVar := range ctnr.Config.Env {
-			splits := strings.SplitN(envVar, "=", 2)
-			if splits[0] == exposedEnv {
-				handler.envs[strings.ToLower(exposedEnv)] = splits[1]
+			if envVar != "" {
+				splits := strings.SplitN(envVar, "=", 2)
+				if splits[0] == exposedEnv {
+					handler.envs[strings.ToLower(exposedEnv)] = splits[1]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If an environment variable is an empty string, cadvisor panics and fails to start